### PR TITLE
Fix unused cache control

### DIFF
--- a/lib/NodeHttpFetcher.js
+++ b/lib/NodeHttpFetcher.js
@@ -166,7 +166,7 @@ HttpFetcher.prototype.request = function (url, methodName) {
     //parse caching headers
     var cacheHeader = {};
     if (response.headers['cache-control']) {
-      Wreck.parseCacheControl(response.headers['cache-control']);
+      cacheHeader = Wreck.parseCacheControl(response.headers['cache-control']);
     }
     var maxAge = 6000;
     if (cacheHeader['max-age']) {


### PR DESCRIPTION
The Cache-Control header on the NodeHTTPFetcher are parsed but not assigned to the `cacheHeader` variable. 

When a request have a 'no-cache' value, it's not taken into account